### PR TITLE
Fix response url type

### DIFF
--- a/dataservice/cache.py
+++ b/dataservice/cache.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from asyncer import asyncify
+from pydantic import HttpUrl
 
 from dataservice.models import Request, Response
 
@@ -129,7 +130,7 @@ async def cache_request(cache: AsyncJsonCache) -> Callable:
             if key in cache:
                 logger.debug(f"Cache hit for {key}")
                 text, data = cache.get(key)
-                return Response(request=request, text=text, data=data, url=key)
+                return Response(request=request, text=text, data=data, url=HttpUrl(key))
             else:
                 logger.debug(f"Cache miss for {key}")
                 response = await req_func(request)

--- a/dataservice/clients.py
+++ b/dataservice/clients.py
@@ -7,6 +7,7 @@ from typing import Annotated, NoReturn
 
 import httpx
 from annotated_types import Ge, Le
+from pydantic import HttpUrl
 
 from dataservice.exceptions import DataServiceException, RetryableException
 from dataservice.models import Request, Response
@@ -91,5 +92,9 @@ class HttpXClient:
 
         logger.info(msg)
         return Response(
-            request=request, text=response.text, data=data, url=str(response.url), headers=dict(response.headers)
+            request=request,
+            text=response.text,
+            data=data,
+            url=HttpUrl(str(response.url)),
+            headers=dict(response.headers),
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "python-dataservice"
 packages = [
     { include = "dataservice"},
 ]
-version = "0.1.2"
+version = "0.1.3"
 description = "Lightweight async data gathering for Python"
 authors = ["NomadMonad <romagnoli.luca@gmail.com>"]
 readme = "README.rst"


### PR DESCRIPTION
Use `HttpUrl` when returning `Response.url`