### PR TITLE
Fix pw init

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,8 +7,6 @@ on:
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true
-
     runs-on: ubuntu-latest
 
     steps:

--- a/dataservice/clients.py
+++ b/dataservice/clients.py
@@ -242,9 +242,11 @@ class PlaywrightClient(BaseClient):
     async def _setup(
         self, request: Request
     ) -> tuple[Browser, BrowserContext, PlaywrightPage, Playwright]:
-        """Setup the Playwright client."""
+        """Set up the Playwright client."""
         playwright = await async_playwright().start()
-        browser = await getattr(playwright, self.config.browser).launch()
+        browser = await getattr(playwright, self.config.browser).launch(
+            headless=self.config.headless
+        )
         context_kwargs = self._get_context_kwargs(request)
         context = await browser.new_context(**context_kwargs)
         page = await context.new_page()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "python-dataservice"
 packages = [
     { include = "dataservice"},
 ]
-version = "0.11.6"
+version = "0.11.7"
 description = "Lightweight async data gathering for Python"
 authors = ["NomadMonad <romagnoli.luca@gmail.com>"]
 readme = "README.rst"


### PR DESCRIPTION
Fix a bug where Playwright client wasn't being passed headless argument and browser type